### PR TITLE
Include wp.tar.gz part of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
 # ========
 
 # wordpress
-ENV WORDPRESS_DOWNLOAD_URL "https://wordpress.org/latest.tar.gz"
 ENV WORDPRESS_SOURCE "/usr/src/wordpress"
 ENV WORDPRESS_HOME "/home/site/wwwroot"
 
@@ -26,13 +25,6 @@ ENV DOCKER_BUILD_HOME "/dockerbuild"
 WORKDIR $DOCKER_BUILD_HOME
 RUN set -ex \
 	# --------
-        # ~ tools
-	# --------
-
-	&& apk add --update \
-	     wget \
-
-	# --------
 	# 1. redis
 	# --------
         && apk add --update redis \
@@ -41,8 +33,7 @@ RUN set -ex \
 	# 2. wordpress
 	# ------------
 	&& mkdir -p $WORDPRESS_SOURCE \
-	&& cd $WORDPRESS_SOURCE \
-	&& wget -O wordpress.tar.gz "$WORDPRESS_DOWNLOAD_URL" --no-check-certificate \ 	
+        # cp in final
 	
 	# ----------
 	# ~. clean up
@@ -64,6 +55,7 @@ RUN set -ex \
 # =====
 # final
 # =====
+COPY wp.tar.gz $WORDPRESS_SOURCE/
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
 EXPOSE 2222 80

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,7 @@ setup_wordpress(){
 	test ! -d "$WORDPRESS_HOME" && echo "INFO: $WORDPRESS_HOME not found. creating ..." && mkdir -p "$WORDPRESS_HOME"
 
 	cd $WORDPRESS_SOURCE
-	tar -xf wordpress.tar.gz -C $WORDPRESS_HOME/ --strip-components=1
+	tar -xf wp.tar.gz -C $WORDPRESS_HOME/ --strip-components=1
 	
 	chown -R www-data:www-data $WORDPRESS_HOME 
     cd $WORDPRESS_HOME


### PR DESCRIPTION
1) add wp.tar.gz.
2) remove installation of "wget".

Tested, can build successfully and run normally.